### PR TITLE
Depayloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,9 +176,4 @@ $RECYCLE.BIN/
 # ignore result content
 /test/results/
 
-# ignore reference boolean encoder in C
-rfc_bool_encoding/
-
-# vscode
-.vscode
 # End of https://www.gitignore.io/api/c,vim,linux,macos,elixir,windows,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -175,4 +175,10 @@ $RECYCLE.BIN/
 
 # ignore result content
 /test/results/
+
+# ignore reference boolean encoder in C
+rfc_bool_encoding/
+
+# vscode
+.vscode
 # End of https://www.gitignore.io/api/c,vim,linux,macos,elixir,windows,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -174,5 +174,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # ignore result content
-results/
+/test/results/
 # End of https://www.gitignore.io/api/c,vim,linux,macos,elixir,windows,visualstudiocode

--- a/lib/depayloader.ex
+++ b/lib/depayloader.ex
@@ -45,12 +45,7 @@ defmodule Membrane.RTP.VP8.Depayloader do
     do: {{:ok, forward: event}, %State{state | frame_acc: nil}}
 
   @impl true
-  def handle_process(
-        :input,
-        buffer,
-        _ctx,
-        state
-      ) do
+  def handle_process(:input, buffer, _ctx, state) do
     with {{:ok, actions}, new_state} <- parse_buffer(buffer, state) do
       {{:ok, actions ++ [redemand: :output]},
        %{new_state | last_buffer_metadata: buffer.metadata}}

--- a/lib/frame.ex
+++ b/lib/frame.ex
@@ -21,7 +21,7 @@ defmodule Membrane.RTP.VP8.Frame do
 
   @spec parse(Buffer.t(), t()) ::
           {:ok, binary(), t()}
-          | {:incomplete, t()}
+          | {:ok, :incomplete, t()}
           | {:error,
              :packet_malformed
              | :invalid_first_packet
@@ -56,7 +56,7 @@ defmodule Membrane.RTP.VP8.Frame do
           t()
         ) ::
           {:ok, binary(), t()}
-          | {:incomplete, t()}
+          | {:ok, :incomplete, t()}
           | {:error, :invalid_first_packet | :missing_packet | :timestamps_not_equal}
   defp do_parse(payload_descriptor, payload, timestamp, sequence_number, acc)
 
@@ -68,7 +68,7 @@ defmodule Membrane.RTP.VP8.Frame do
          sequence_number,
          %__MODULE__{fragments: []} = acc
        ) do
-    {:incomplete,
+    {:ok, :incomplete,
      %{acc | last_seq_num: sequence_number, last_timestamp: timestamp, fragments: [payload]}}
   end
 
@@ -106,7 +106,8 @@ defmodule Membrane.RTP.VP8.Frame do
          %__MODULE__{last_seq_num: last_seq_num, last_timestamp: last_timestamp} = acc
        )
        when is_next(last_seq_num, sequence_number) and equal_timestamp(last_timestamp, timestamp) do
-    {:incomplete, %{acc | last_seq_num: sequence_number, fragments: [payload | acc.fragments]}}
+    {:ok, :incomplete,
+     %{acc | last_seq_num: sequence_number, fragments: [payload | acc.fragments]}}
   end
 
   # either timestamps are not equal or packet is missing

--- a/test/depayloader_test.exs
+++ b/test/depayloader_test.exs
@@ -49,7 +49,7 @@ defmodule Membrane.RTP.VP8.DepayloaderTest do
                  {:output,
                   %Buffer{
                     payload: <<170, 171, 172, 173>>,
-                    metadata: %{rtp: %{sequence_number: 14_451, timestamp: 30}}
+                    metadata: %{rtp: %{sequence_number: 14_450, timestamp: 30}}
                   }},
                end_of_stream: :output
              ]}, %State{}} == Depayloader.handle_end_of_stream(:input, nil, depayloader_state)


### PR DESCRIPTION
Following PR introduces three important modules:
* `Membrane.RTP.VP8.Depayloader`- responsible for implementing `Membrane.Filter` callbacks. This module utilises `Membrane.RTP.VP8.Frame` module for frame reconstruction.
* `Membrane.RTP.VP8.Frame` - provides `Frame` struct that acts as accumulator and multiple functions used for reconstructing VP8 frame.
* `Membrane.RTP.VP8.PayloadDescriptor` - provides `PayloadDescriptor` structure and functions for dealing with that structure - as for now parsing it.