### PR TITLE
Reduce garbage produced when processing buffers

### DIFF
--- a/test/depayloader_with_session_bin_test.exs
+++ b/test/depayloader_with_session_bin_test.exs
@@ -4,7 +4,7 @@ defmodule Membrane.RTP.VP8.DepayloaderWithSessionBinTest do
   import Membrane.Testing.Assertions
 
   alias Membrane.Testing
-  alias Membrane.{RTP, Buffer}
+  alias Membrane.RTP
   alias Membrane.Element.IVF
 
   @results_dir "./test/results"

--- a/test/payloader_test.exs
+++ b/test/payloader_test.exs
@@ -2,7 +2,6 @@ defmodule Membrane.RTP.VP8.PayloaderTest do
   use ExUnit.Case
 
   alias Membrane.RTP.VP8.Payloader
-  alias Membrane.RTP.VP8.Payloader.State
   alias Membrane.RTP.VP8.PayloadDescriptor
   alias Membrane.Buffer
 


### PR DESCRIPTION
This also removes `redemand` where I think it's not needed. I still don't 100% understand redemand, but it seems as if redemand is only needed when:
* There is an error processing a packet.
* An incomplete packet is received.
