### PR TITLE
Fixing session bin integration test

### DIFF
--- a/test/membrane_rtp_vp8/session_bin_integration_test.exs
+++ b/test/membrane_rtp_vp8/session_bin_integration_test.exs
@@ -1,6 +1,5 @@
 defmodule Membrane.RTP.VP8.SessionBinIntegrationTest do
   use ExUnit.Case
-  @moduletag :tmp_dir
 
   import Membrane.ChildrenSpec
   import Membrane.Testing.Assertions
@@ -10,6 +9,8 @@ defmodule Membrane.RTP.VP8.SessionBinIntegrationTest do
   alias Membrane.Element.IVF
   alias Membrane.RTP
   alias Membrane.Testing
+
+  @moduletag :tmp_dir
 
   @rtp_input %{
     pcap: "test/fixtures/input_vp8.pcap",


### PR DESCRIPTION
The tests fail sometimes on CI when `membrane_rtp_plugin` v0.22.0 was put to `mix.exs`.

The reason was that one of `session_bin_integration_tests` has used a directory created in another test. Using new rtp plugin slowed down one process which switched the order of test execution.  
(By the way I'm not that smart, @mickel8 is)

I've solved it by using exunit `tmp_dir` tag instead of `membrane_file_plugin`.

